### PR TITLE
feat: bumped http provider versions to 2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.0",
-    "apache-airflow-providers-http",
+    "apache-airflow-providers-http>=2.0.0",
     "apache-airflow-providers-cncf-kubernetes",
     "pyyaml",
     "packaging",


### PR DESCRIPTION
Update the minimum required version of apache-airflow-providers-http to 2.0.0+ in our dependencies.